### PR TITLE
챗 선택 페이지 작성

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html {
+  --tw-bg-opacity: 1;
+  background-color: rgb(245 245 245 / var(--tw-bg-opacity)) /* #f5f5f5 */;
+}

--- a/components/chat/button/SelectPerson.vue
+++ b/components/chat/button/SelectPerson.vue
@@ -10,18 +10,10 @@
   </button>
 </template>
 
-<script lang="ts">
-export default {
-  name: "SelectPersonButton",
-  props: {
-    text: {
-      type: String,
-      required: true,
-    },
-    isActive: {
-      type: Boolean,
-      default: false,
-    },
-  },
-};
+<script setup lang="ts">
+interface PropTypes {
+  text: string;
+  isActive: boolean;
+}
+const { text, isActive } = defineProps<PropTypes>();
 </script>

--- a/components/global/button/Submit.vue
+++ b/components/global/button/Submit.vue
@@ -1,0 +1,9 @@
+<template>
+  <button
+    class="px-4 py-2 rounded-lg border-2 bg-neutral-500 text-white"
+    @click="logout"
+  >
+    로그아웃
+  </button>
+</template>
+<script setup lang="ts"></script>

--- a/components/index/list/Chat.vue
+++ b/components/index/list/Chat.vue
@@ -1,0 +1,17 @@
+<template>
+  <li
+    class="flex items-center justify-between rounded-lg bg-white shadow-sm py-3 px-5"
+  >
+    <div class="flex flex-col gap-1">
+      <h2 class="font-bold">title</h2>
+      <p class="text-sm">description...</p>
+    </div>
+    <div>
+      <ChevronRightIcon class="text-black size-6" />
+    </div>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { ChevronRightIcon } from "@heroicons/vue/24/solid";
+</script>

--- a/components/index/list/Chat.vue
+++ b/components/index/list/Chat.vue
@@ -1,17 +1,26 @@
 <template>
-  <li
-    class="flex items-center justify-between rounded-lg bg-white shadow-sm py-3 px-5"
-  >
-    <div class="flex flex-col gap-1">
-      <h2 class="font-bold">title</h2>
-      <p class="text-sm">description...</p>
-    </div>
-    <div>
-      <ChevronRightIcon class="text-black size-6" />
-    </div>
-  </li>
+  <NuxtLink :to="`/chat/${id}`">
+    <li
+      class="flex items-center justify-between rounded-lg bg-white shadow-sm py-3 px-5"
+    >
+      <div class="flex flex-col gap-1">
+        <h2 class="font-bold">{{ title }}</h2>
+        <p class="text-sm">{{ description }}</p>
+      </div>
+      <div>
+        <ChevronRightIcon class="text-black size-6" />
+      </div>
+    </li>
+  </NuxtLink>
 </template>
 
 <script setup lang="ts">
 import { ChevronRightIcon } from "@heroicons/vue/24/solid";
+
+interface PropTypes {
+  id: number;
+  title: string;
+  description: string;
+}
+const { id, title, description } = defineProps<PropTypes>();
 </script>

--- a/constants/session-const.ts
+++ b/constants/session-const.ts
@@ -1,1 +1,9 @@
-export const SESSION_NAME = "bubble-maker-session";
+export const GET_SESSION_CONFIG = {
+  name: process.env.SESSION_NAME,
+  password: process.env.SESSION_PW!,
+};
+
+export const USE_SESSION_CONFIG = {
+  ...GET_SESSION_CONFIG,
+  maxAge: 60 * 60 * 24 * 30, // 30 days
+};

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,5 @@
+<template>
+  <main>
+    <slot />
+  </main>
+</template>

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,21 +1,19 @@
 import { defineNuxtRouteMiddleware } from "nuxt/app";
-import { parseCookies } from "h3";
+import { useSession } from "h3";
 import { useNuxtApp } from "#app";
-import { SESSION_NAME } from "~/constants/session-const";
+import { USE_SESSION_CONFIG } from "~/constants/session-const";
 
 export default defineNuxtRouteMiddleware(async (to, from) => {
   const { ssrContext } = useNuxtApp();
 
   if (ssrContext) {
     const event = useRequestEvent();
-    const cookies = parseCookies(event!);
-    const session = cookies[SESSION_NAME];
+    const { data } = await useSession(event!, USE_SESSION_CONFIG);
 
-    if (!session && to.path !== "/login") {
+    if (!data?.userId && to.path !== "/login") {
       return navigateTo("/login");
     }
-
-    if (session && to.path === "/login") {
+    if (data?.userId && to.path === "/login") {
       return navigateTo("/");
     }
   }

--- a/pages/chat/[id]/index.vue
+++ b/pages/chat/[id]/index.vue
@@ -43,8 +43,8 @@
       <div
         class="self-center mt-4 px-4 py-2 flex gap-2 bg-neutral-100 w-fit rounded-lg"
       >
-        <SelectPersonButton :isActive="true" text="나" />
-        <SelectPersonButton :isActive="false" text="상대방" />
+        <ChatButtonSelectPerson :isActive="true" text="나" />
+        <ChatButtonSelectPerson :isActive="false" text="상대방" />
       </div>
       <div class="flex gap-4 p-4">
         <input
@@ -64,8 +64,6 @@
 
 <script setup lang="ts">
 // TODO: 최종적으로 스크린샷 생성하는 매커니즘은 어떻게 만들건지? dom-to-image? html-to-image?
-
-import SelectPersonButton from "~/components/select-person-button.vue";
 
 const { data: users } = await useAsyncData("users", async () =>
   $fetch("/api/users")

--- a/pages/chat/[id]/index.vue
+++ b/pages/chat/[id]/index.vue
@@ -64,10 +64,4 @@
 
 <script setup lang="ts">
 // TODO: 최종적으로 스크린샷 생성하는 매커니즘은 어떻게 만들건지? dom-to-image? html-to-image?
-
-const { data: users } = await useAsyncData("users", async () =>
-  $fetch("/api/users")
-);
-
-console.log(users);
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,11 +6,21 @@
   >
     로그아웃
   </button>
+  <div class="p-4">
+    <ul class="flex flex-col gap-3">
+      <IndexListChat
+        v-for="chat in chats"
+        :key="chat.id"
+        :id="chat.id"
+        :title="chat.title"
+        :description="chat.description"
+      />
+    </ul>
+  </div>
 </template>
 
 <script setup lang="ts">
 import type { PostLogoutResponse } from "~/server/api/logout.post";
-
 const router = useRouter();
 
 async function logout() {
@@ -22,4 +32,6 @@ async function logout() {
     router.push({ path: "/login" });
   }
 }
+
+const { chats } = await $fetch<GetChatsResponse>("/api/chats");
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,11 +17,21 @@
       />
     </ul>
   </div>
+  <button
+    class="w-14 h-14 bg-orange-400 flex justify-center items-center rounded-xl shadow-lg fixed right-8 bottom-8 hover:bg-orange-500 transition-colors"
+    @click="createChat"
+  >
+    <PlusIcon class="size-8 text-white" />
+  </button>
 </template>
 
 <script setup lang="ts">
 import type { PostLogoutResponse } from "~/server/api/logout.post";
+import type { CreateChatResponse } from "~/server/api/chat.post";
+import { PlusIcon } from "@heroicons/vue/24/solid";
 const router = useRouter();
+
+const { chats } = await $fetch<GetChatsResponse>("/api/chats");
 
 async function logout() {
   const response = await $fetch<PostLogoutResponse>("/api/logout", {
@@ -33,5 +43,14 @@ async function logout() {
   }
 }
 
-const { chats } = await $fetch<GetChatsResponse>("/api/chats");
+async function createChat() {
+  const response = await $fetch<CreateChatResponse>("/api/chat", {
+    method: "POST",
+  });
+
+  if (response.ok) {
+    const newChatId = response.chatId;
+    router.push({ path: `/chat/${newChatId}` });
+  }
+}
 </script>

--- a/server/api/chat.post.ts
+++ b/server/api/chat.post.ts
@@ -1,0 +1,44 @@
+import prisma from "~/lib/prisma";
+import { GET_SESSION_CONFIG } from "~/constants/session-const";
+
+export interface CreateChatResponse {
+  ok: boolean;
+  chatId: number;
+}
+
+async function createChat(userId: number) {
+  const chat = await prisma.chat.create({
+    data: {
+      title: "새로운 챗",
+      description: "설명이 없습니다.",
+      userId,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return chat;
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const {
+      data: { userId },
+    } = await getSession(event, GET_SESSION_CONFIG);
+
+    const chat = await createChat(userId);
+
+    console.log("chat", chat);
+
+    return {
+      ok: true,
+      chatId: chat.id,
+    };
+  } catch {
+    return {
+      ok: false,
+      chatId: undefined,
+    };
+  }
+});

--- a/server/api/chats.get.ts
+++ b/server/api/chats.get.ts
@@ -1,0 +1,46 @@
+import prisma from "~/lib/prisma";
+import { GET_SESSION_CONFIG } from "~/constants/session-const";
+import { Chat } from "@prisma/client";
+
+export interface GetChatsResponse {
+  ok: boolean;
+  chats: Chat;
+}
+
+async function getChats(userId: number) {
+  const chats = await prisma.chat.findMany({
+    where: {
+      userId,
+    },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      createdAt: true,
+      updatedAt: true,
+      _count: true,
+    },
+  });
+
+  return chats;
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const {
+      data: { userId },
+    } = await getSession(event, GET_SESSION_CONFIG);
+
+    const chats = await getChats(userId);
+
+    return {
+      ok: true,
+      chats,
+    };
+  } catch {
+    return {
+      ok: false,
+      chats: [],
+    };
+  }
+});

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -1,5 +1,5 @@
 import prisma from "~/lib/prisma";
-import { SESSION_NAME } from "~/constants/session-const";
+import { USE_SESSION_CONFIG } from "~/constants/session-const";
 
 export interface PostLoginResponse {
   ok: boolean;
@@ -55,7 +55,9 @@ export default defineEventHandler(async (event) => {
     };
   }
 
-  setCookie(event, SESSION_NAME, JSON.stringify({ id: userId, email }));
+  const session = await useSession(event, USE_SESSION_CONFIG);
+  await session.update({ userId, email });
+
   return {
     ok: true,
   };

--- a/server/api/logout.post.ts
+++ b/server/api/logout.post.ts
@@ -1,10 +1,20 @@
-import { SESSION_NAME } from "~/constants/session-const";
+import { USE_SESSION_CONFIG } from "~/constants/session-const";
 
 export interface PostLogoutResponse {
   ok: boolean;
 }
 
 export default defineEventHandler(async (event) => {
-  deleteCookie(event, SESSION_NAME);
-  return { ok: true };
+  try {
+    const session = await useSession(event, USE_SESSION_CONFIG);
+    await session.clear();
+
+    return {
+      ok: true,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+    };
+  }
 });


### PR DESCRIPTION
## 설명

챗 선택 페이지를 작성한다. URL은 `/`로 한다.

## 해당 브랜치에서 할 일

- [x]  챗의 목록을 표시하는 화면을 작성한다.
- [x]  챗을 누르면 해당 톡 화면으로 이동하는 기능을 추가한다.
- [x]  새로운 챗 추가하는 기능 작성

## 계획에 없었는데 함께 끝낸 일

- nuxt의 컴포넌트 규칙에 대해 배우고, 명명룰을 확립
- nuxt 기본 쿠키 함수 대신에 h3 활용하여 iron session처럼 암호화된 세션 구현
- 백엔드에서 세션 정보 불러오는 방법 정의 [(래퍼 함수로 더 개선할 수 있을지도. 이슈 작성함)](https://www.notion.so/10f49d6e43278079b81ec29af4fbe84e?pvs=21)

## 메모

### Nuxt의 컴포넌트 구조

nuxt의 컴포넌트 이름은 디렉토리 구조를 따라서 알아서 만들어진다. 사용할 때 import 할 필요도 없다.

- global
    - button
    - list
- index
    - button
    - list
- chat
    - button
    - list

### 발생했던 에러: Vue app aliases are not allowed in server runtime.

세션을 래퍼 함수로 작성하려는 시도 중에 이 에러가 발생했다. 백엔드 코드에서 로컬 파일을 참조할 때는 물결 표시로 시작하는 임포트를 사용할 때 주의해야한다.