### PR TITLE
세션 불러오는 래퍼 함수 작성

### DIFF
--- a/constants/session-const.ts
+++ b/constants/session-const.ts
@@ -1,9 +1,0 @@
-export const GET_SESSION_CONFIG = {
-  name: process.env.SESSION_NAME,
-  password: process.env.SESSION_PW!,
-};
-
-export const USE_SESSION_CONFIG = {
-  ...GET_SESSION_CONFIG,
-  maxAge: 60 * 60 * 24 * 30, // 30 days
-};

--- a/lib/withSession.ts
+++ b/lib/withSession.ts
@@ -1,0 +1,24 @@
+import { useSession } from "h3";
+import type { H3Event } from "h3";
+
+export const GET_SESSION_CONFIG = {
+  name: process.env.SESSION_NAME,
+  password: process.env.SESSION_PW!,
+};
+
+export const USE_SESSION_CONFIG = {
+  ...GET_SESSION_CONFIG,
+  maxAge: 60 * 60 * 24 * 30, // 30 days
+};
+
+export async function withUseSession(event: H3Event) {
+  const session = await useSession(event, USE_SESSION_CONFIG);
+
+  return session;
+}
+
+export async function withGetSession(event: H3Event) {
+  const session = await getSession(event, GET_SESSION_CONFIG);
+
+  return session;
+}

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,8 +1,7 @@
-import { defineNuxtRouteMiddleware } from "nuxt/app";
-import { useSession } from "h3";
-import { useNuxtApp } from "#app";
-import { USE_SESSION_CONFIG } from "~/constants/session-const";
 import prisma from "~/lib/prisma";
+import { defineNuxtRouteMiddleware } from "nuxt/app";
+import { useNuxtApp } from "#app";
+import { withUseSession } from "~/lib/withSession";
 
 async function validateUser(userId: number) {
   if (!userId) return false;
@@ -24,13 +23,11 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   if (ssrContext) {
     const event = useRequestEvent();
-    const session = await useSession(event!, USE_SESSION_CONFIG);
-
+    const session = await withUseSession(event!);
     const isUserValid = await validateUser(+session.data?.userId);
 
     if (!isUserValid && to.path !== "/login") {
       await session.clear();
-
       return navigateTo("/login");
     }
     if (isUserValid && to.path === "/login") {

--- a/pages/chat/[id]/index.vue
+++ b/pages/chat/[id]/index.vue
@@ -2,7 +2,7 @@
   <div>
     <div
       ref="chatArea"
-      class="bg-sky-200 p-4 min-h-screen overflow-y-scroll mb-56 flex flex-col gap-4"
+      class="bg-sky-200 p-4 min-h-[calc(100vh-224px)] overflow-y-scroll mb-56 flex flex-col gap-4"
     >
       <Message
         v-for="message in messages"

--- a/server/api/chat/index.post.ts
+++ b/server/api/chat/index.post.ts
@@ -1,5 +1,5 @@
 import prisma from "~/lib/prisma";
-import { GET_SESSION_CONFIG } from "~/constants/session-const";
+import { withGetSession } from "~/lib/withSession";
 
 export interface CreateChatResponse {
   ok: boolean;
@@ -25,7 +25,7 @@ export default defineEventHandler(async (event) => {
   try {
     const {
       data: { userId },
-    } = await getSession(event, GET_SESSION_CONFIG);
+    } = await withGetSession(event);
 
     const chat = await createChat(userId);
 

--- a/server/api/chats/index.get.ts
+++ b/server/api/chats/index.get.ts
@@ -1,6 +1,6 @@
 import prisma from "~/lib/prisma";
-import { GET_SESSION_CONFIG } from "~/constants/session-const";
 import { Chat } from "@prisma/client";
+import { withGetSession } from "~/lib/withSession";
 
 export interface GetChatsResponse {
   ok: boolean;
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
   try {
     const {
       data: { userId },
-    } = await getSession(event, GET_SESSION_CONFIG);
+    } = await withGetSession(event);
 
     const chats = await getChats(userId);
 

--- a/server/api/login.post.ts
+++ b/server/api/login.post.ts
@@ -1,5 +1,5 @@
 import prisma from "~/lib/prisma";
-import { USE_SESSION_CONFIG } from "~/constants/session-const";
+import { withUseSession } from "~/lib/withSession";
 
 export interface PostLoginResponse {
   ok: boolean;
@@ -55,7 +55,7 @@ export default defineEventHandler(async (event) => {
     };
   }
 
-  const session = await useSession(event, USE_SESSION_CONFIG);
+  const session = await withUseSession(event);
   await session.update({ userId, email });
 
   return {

--- a/server/api/logout.post.ts
+++ b/server/api/logout.post.ts
@@ -1,4 +1,4 @@
-import { USE_SESSION_CONFIG } from "~/constants/session-const";
+import { withUseSession } from "~/lib/withSession";
 
 export interface PostLogoutResponse {
   ok: boolean;
@@ -6,7 +6,7 @@ export interface PostLogoutResponse {
 
 export default defineEventHandler(async (event) => {
   try {
-    const session = await useSession(event, USE_SESSION_CONFIG);
+    const session = await withUseSession(event);
     await session.clear();
 
     return {

--- a/server/api/message/index.post.ts
+++ b/server/api/message/index.post.ts
@@ -1,6 +1,6 @@
 import prisma from "~/lib/prisma";
-import { GET_SESSION_CONFIG } from "~/constants/session-const";
 import { Message } from "@prisma/client";
+import { withGetSession } from "~/lib/withSession";
 
 export interface CreateMessageResponse {
   ok: boolean;
@@ -36,7 +36,7 @@ export default defineEventHandler(async (event) => {
   try {
     const {
       data: { userId },
-    } = await getSession(event, GET_SESSION_CONFIG);
+    } = await withGetSession(event);
     const { sender, text, chatId } = await readBody(event);
 
     const message = await createMessage({

--- a/server/api/messages/index.get.ts
+++ b/server/api/messages/index.get.ts
@@ -1,6 +1,6 @@
 import prisma from "~/lib/prisma";
-import { GET_SESSION_CONFIG } from "~/constants/session-const";
 import { Message } from "@prisma/client";
+import { withGetSession } from "~/lib/withSession";
 
 export interface GetMessagesResponse {
   ok: boolean;
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event) => {
   try {
     const {
       data: { userId },
-    } = await getSession(event, GET_SESSION_CONFIG);
+    } = await withGetSession(event);
     const { chatId } = getQuery(event);
 
     if (!chatId) {


### PR DESCRIPTION
## 설명

지금 세션 불러오는 `getSession` 이나 `useSession` 함수가 단순히 const에 정의된 config를 불러오는 식으로 동작하고 있는데, 그것보단 래퍼 함수로 한 번에 세션을 정의할 수 있으면 좋을 것 같음.

## 해당 브랜치에서 할 일

- [x]  getSession 래퍼 함수로 만들기
- [x]  useSession 래퍼 함수로 만들기
- [x]  clearSession 래퍼 함수로 만들기 → useSession 후에 session.clear로 대응할 수 있으므로 따로 작성하지 않음

## 계획에 없었는데 함께 끝낸 일

- 챗 상세화면에서 챗 최대 높이 수정
